### PR TITLE
修复 basePath 路径拼接问题

### DIFF
--- a/src/libs/settings.ts
+++ b/src/libs/settings.ts
@@ -203,12 +203,13 @@ class GitHubSettings {
      * 获取当前配置
      */
     getConfig(): GitHubConfig {
+        const basePath = this.settingUtils.get("basePath");
         return {
             username: this.settingUtils.get("githubUsername") || "",
             accessToken: this.settingUtils.get("accessToken") || "",
             repository: this.settingUtils.get("repository") || "",
             branch: this.settingUtils.get("branch") || "main",
-            basePath: this.settingUtils.get("basePath") || "content/posts",
+            basePath: basePath !== undefined && basePath !== null ? basePath : "content/posts",
             customDomain: this.settingUtils.get("customDomain") || "",
             frontMatter: this.settingUtils.get("frontMatter") || ""
         };


### PR DESCRIPTION
## 问题描述

当前版本在处理 `basePath` 配置时存在以下问题：

- 无法使用空路径：当用户希望将文件上传到仓库根目录时，将 `basePath` 设置为空字符串会被强制替换为`"content/posts"`
- 斜杠处理不当：当 `basePath` 设置为 `"/"` 时，路径拼接会产生双斜杠（如 `//folder/index.md`），导致路径错误

这些问题限制了用户的灵活性，无法将文件直接上传到仓库根目录。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path normalization and handling for consistent URL/file path construction across the application.
  * Enhanced base path configuration handling to properly support empty and custom path values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->